### PR TITLE
Gradle configuration changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ bin
 *.iml
 .idea
 
+#vscode
+.vscode
+
 # don't want compiled jars in the repo
 out
 mcinterfaceforge1182

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,9 +20,12 @@ val buildAllTask = tasks.register("buildForgeAll") registerAll@ {
 }
 
 for((name, moduleName) in platforms) {
+    print("GOT MODULENAME ")
+    println(moduleName)
     val module = project(moduleName)
-
-    tasks.register("build${ name.replaceFirstChar(Char::titlecase).replace(".", "").replace("-", "") }") {
+    val taskName = "build${ name.replaceFirstChar(Char::titlecase).replace(".", "").replace("-", "") }"
+    
+    tasks.register(taskName) {
         group = "build"
         doFirst {
             preBuild()
@@ -35,6 +38,10 @@ for((name, moduleName) in platforms) {
             dependsOn(this@register)
         }
     }
+    print("registered task ")
+    print(taskName)
+    print(" from module ")
+    println(moduleName)
 }
 
 fun moveToOut(subProject: Project, versionStr: String) {

--- a/mcinterfaceforge1165/build.gradle
+++ b/mcinterfaceforge1165/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: "net.minecraftforge.gradle", name: "ForgeGradle", version: "5.1.+", changing: true
+        classpath group: "net.minecraftforge.gradle", name: "ForgeGradle", version: "6.0.+", changing: true
         classpath group: "org.parchmentmc", name: "librarian", version: "1.+"
         classpath group: "org.spongepowered", name: "mixingradle", version: "0.7.+"
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -42,8 +42,10 @@ platforms.removeAt(0) // because first element is null
 
 Files.walk(Paths.get("."),1)
     .filter { Files.isDirectory(it) }
-    .filter {it.toString().matches(Regex(".\\/mcinterface.*"))}
+    //TODO Find a way to change gradle version or forgegradle plugin for 1.12.2 version
+    // because of     /mcinterfaceforge1122/build.gradle:7
     .filter{ it.toString() != "./mcinterfaceforge1122"}
+    .filter {it.toString().matches(Regex(".\\/mcinterface.*"))} 
     .forEach {
         val module = it.toString().replace(".", "").replace("/", "")
         val dirName = it.toString().replace("./", "")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 pluginManagement {
     repositories {
         maven { url = uri("https://maven.fabricmc.net/") }
@@ -7,19 +11,58 @@ pluginManagement {
     }
 }
 
+plugins{
+    "kotlin-dsl"
+}
+
 rootProject.name = "Immersive Vehicles"
 include("mccore")
 
-println("Enabled platforms:")
+// println("Enabled platforms:")
+// ext.set("enabled_platforms","forge-1.20.1")
+// (ext.get("enabled_platforms") as? String)
+//     ?.split(',')
+//     ?.map { platform ->
+//         val platformTrimmed = platform.trim()
+//         val module = ":mcinterface${ platformTrimmed.replace(".", "").replace("-", "") }"
+//         include(module)
+//         println("- $platformTrimmed ($module)")
+//         platformTrimmed to module
+//     }
+//     .orEmpty()
+//     .also { gradle.extra["platforms"] = it }
 
-(ext.get("enabled_platforms") as? String)
-    ?.split(',')
-    ?.map { platform ->
-        val platformTrimmed = platform.trim()
-        val module = ":mcinterface${ platformTrimmed.replace(".", "").replace("-", "") }"
+
+
+// This allows to have any mcinterface without changing settings
+
+
+val platforms = mutableListOf(Pair("",""))
+platforms.removeAt(0) // because first element is null
+
+Files.walk(Paths.get("."),1)
+    .filter { Files.isDirectory(it) }
+    .filter {it.toString().matches(Regex(".\\/mcinterface.*"))}
+    .filter{ it.toString() != "./mcinterfaceforge1122"}
+    .forEach {
+        val module = it.toString().replace(".", "").replace("/", "")
+        val dirName = it.toString().replace("./", "")
+
+        // Assuming that version is not release candidate / snapshot / anything non usual
+        val noDotsVersion = module.replace("mcinterfaceforge","").split("")
+        val majorVersion = noDotsVersion[1].toString()
+        val minorVersion = noDotsVersion[2].toString() + noDotsVersion[3].toString()
+        val patchVersion = noDotsVersion[4].toString()
+
+        val stringDottedVersion = "forge-" +majorVersion.toString() + "." + minorVersion.toString() + "." + patchVersion.toString()
+        
+        print("Found platform ")
+        print(module)
+        print(" for version ")
+        println(stringDottedVersion)
         include(module)
-        println("- $platformTrimmed ($module)")
-        platformTrimmed to module
-    }
-    .orEmpty()
-    .also { gradle.extra["platforms"] = it }
+        platforms.add(Pair(stringDottedVersion,":"+module))
+        }
+
+gradle.extra["platforms"] = platforms
+


### PR DESCRIPTION
1.Now all mcinterfaceforge* including and registering as tasks automatically (except 1.12.2 because of low gradle version requirement)
2. 1.16.5 interface now can be built without changing gradle/gradle-wrapper.properties version

(As there are no issues tab, telling here. 1.20.1 can not be built as
Failed to setup Minecraft, java.lang.IllegalStateException: Cannot mutate content repository descriptor 'LoomLocalRemappedMods after repository has been used
(2 days of active googleing did not helped)
)
